### PR TITLE
Avoid GitHub API for update checks

### DIFF
--- a/cmd/update/update.go
+++ b/cmd/update/update.go
@@ -4,11 +4,11 @@ import (
 	"archive/tar"
 	"compress/gzip"
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"log"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -21,8 +21,8 @@ import (
 )
 
 const (
-	releaseAPIURL = "https://api.github.com/repos/wim-web/tnnl/releases/latest"
-	binaryName    = "tnnl"
+	latestReleaseURL = "https://github.com/wim-web/tnnl/releases/latest"
+	binaryName       = "tnnl"
 )
 
 var UpdateCmd = &cobra.Command{
@@ -36,13 +36,8 @@ var UpdateCmd = &cobra.Command{
 }
 
 type release struct {
-	TagName string      `json:"tag_name"`
-	Assets  []assetInfo `json:"assets"`
-}
-
-type assetInfo struct {
-	Name        string `json:"name"`
-	DownloadURL string `json:"browser_download_url"`
+	TagName         string
+	DownloadBaseURL string
 }
 
 func init() {
@@ -103,43 +98,78 @@ func updateCLI() error {
 }
 
 func fetchLatestRelease() (release, error) {
+	return fetchLatestReleaseFromRedirect()
+}
+
+func fetchLatestReleaseFromRedirect() (release, error) {
 	reqCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, releaseAPIURL, nil)
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, latestReleaseURL, nil)
 	if err != nil {
 		return release{}, err
 	}
-	req.Header.Set("Accept", "application/vnd.github+json")
 	req.Header.Set("User-Agent", fmt.Sprintf("%s/%s", binaryName, cmd.Version))
 
-	res, err := http.DefaultClient.Do(req)
+	client := *http.DefaultClient
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+
+	res, err := client.Do(req)
 	if err != nil {
 		return release{}, err
 	}
 	defer res.Body.Close()
 
-	if res.StatusCode != http.StatusOK {
+	if res.StatusCode < http.StatusMultipleChoices || res.StatusCode >= http.StatusBadRequest {
 		body, _ := io.ReadAll(io.LimitReader(res.Body, 4*1024))
-		return release{}, fmt.Errorf("failed to fetch latest release: status=%d body=%s", res.StatusCode, strings.TrimSpace(string(body)))
+		return release{}, fmt.Errorf("failed to fetch latest release redirect: status=%d body=%s", res.StatusCode, strings.TrimSpace(string(body)))
 	}
 
-	var rel release
-	if err := json.NewDecoder(res.Body).Decode(&rel); err != nil {
+	tagName, err := releaseTagFromLatestLocation(res.Header.Get("Location"))
+	if err != nil {
 		return release{}, err
 	}
-	if rel.TagName == "" {
-		return release{}, fmt.Errorf("latest release tag is empty")
+
+	return release{
+		TagName:         tagName,
+		DownloadBaseURL: fmt.Sprintf("https://github.com/wim-web/tnnl/releases/download/%s", url.PathEscape(tagName)),
+	}, nil
+}
+
+func releaseTagFromLatestLocation(location string) (string, error) {
+	if location == "" {
+		return "", fmt.Errorf("latest release redirect location is empty")
 	}
 
-	return rel, nil
+	u, err := url.Parse(location)
+	if err != nil {
+		return "", err
+	}
+
+	const marker = "/releases/tag/"
+	escapedPath := u.EscapedPath()
+	idx := strings.Index(escapedPath, marker)
+	if idx < 0 {
+		return "", fmt.Errorf("latest release redirect location does not contain release tag: %s", location)
+	}
+
+	rawTagName := strings.TrimPrefix(escapedPath[idx:], marker)
+	tagName, err := url.PathUnescape(rawTagName)
+	if err != nil {
+		return "", err
+	}
+	if tagName == "" {
+		return "", fmt.Errorf("latest release tag is empty")
+	}
+
+	return tagName, nil
 }
 
 func (r release) assetURL(assetName string) (string, error) {
-	for _, a := range r.Assets {
-		if a.Name == assetName {
-			return a.DownloadURL, nil
-		}
+	if r.DownloadBaseURL != "" {
+		return strings.TrimRight(r.DownloadBaseURL, "/") + "/" + url.PathEscape(assetName), nil
 	}
 
 	return "", fmt.Errorf("release asset not found: %s", assetName)

--- a/cmd/update/update_test.go
+++ b/cmd/update/update_test.go
@@ -1,12 +1,53 @@
 package update
 
 import (
+	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/wim-web/tnnl/cmd"
 )
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestFetchLatestReleaseUsesLatestReleaseRedirect(t *testing.T) {
+	originalClient := http.DefaultClient
+	t.Cleanup(func() {
+		http.DefaultClient = originalClient
+	})
+
+	http.DefaultClient = &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if got, want := req.URL.String(), latestReleaseURL; got != want {
+				t.Fatalf("request URL = %q, want %q", got, want)
+			}
+			if got := req.Header.Get("Authorization"); got != "" {
+				t.Fatalf("Authorization header = %q, want empty", got)
+			}
+
+			return &http.Response{
+				StatusCode: http.StatusFound,
+				Body:       http.NoBody,
+				Header: http.Header{
+					"Location": []string{"https://github.com/wim-web/tnnl/releases/tag/v1.2.3"},
+				},
+			}, nil
+		}),
+	}
+
+	got, err := fetchLatestRelease()
+	if err != nil {
+		t.Fatalf("fetchLatestRelease() error = %v", err)
+	}
+	if want := "v1.2.3"; got.TagName != want {
+		t.Fatalf("fetchLatestRelease().TagName = %q, want %q", got.TagName, want)
+	}
+}
 
 func TestNormalizeVersion(t *testing.T) {
 	tests := []struct {
@@ -43,13 +84,8 @@ func TestNormalizeVersion(t *testing.T) {
 
 func TestAssetURL(t *testing.T) {
 	rel := release{
-		TagName: "v0.6.0",
-		Assets: []assetInfo{
-			{
-				Name:        "tnnl_darwin_arm64.tar.gz",
-				DownloadURL: "https://example.com/tnnl_darwin_arm64.tar.gz",
-			},
-		},
+		TagName:         "v0.6.0",
+		DownloadBaseURL: "https://github.com/wim-web/tnnl/releases/download/v0.6.0",
 	}
 
 	got, err := rel.assetURL("tnnl_darwin_arm64.tar.gz")
@@ -57,7 +93,7 @@ func TestAssetURL(t *testing.T) {
 		t.Fatalf("assetURL() unexpected error: %v", err)
 	}
 
-	if want := "https://example.com/tnnl_darwin_arm64.tar.gz"; got != want {
+	if want := "https://github.com/wim-web/tnnl/releases/download/v0.6.0/tnnl_darwin_arm64.tar.gz"; got != want {
 		t.Fatalf("assetURL() = %q, want %q", got, want)
 	}
 }


### PR DESCRIPTION
## Summary
- Fetch the latest release through the public GitHub releases/latest redirect instead of the REST API.
- Derive release asset download URLs from the redirected tag.
- Add tests for redirect-based release lookup without Authorization headers.

## Test Plan
- go test -count=1 ./...