### PR TITLE
fix: seed exec input skeleton with default command sh

### DIFF
--- a/cmd/exec/make_input_file.go
+++ b/cmd/exec/make_input_file.go
@@ -5,7 +5,7 @@ import (
 	"github.com/wim-web/tnnl/internal/input"
 )
 
-var MakeInputFileCmd = inputfile.New("exec", "exec-input.json", input.ExecInput{})
+var MakeInputFileCmd = inputfile.New("exec", "exec-input.json", input.ExecInput{Cmd: "sh"})
 
 func init() {
 	ExecCmd.AddCommand(MakeInputFileCmd)


### PR DESCRIPTION
## Summary
- `tnnl exec make-input-file` が生成するスケルトンに `"command": ""` が含まれ、`ResolveExec` のデフォルト `sh` が空文字で上書きされるため、生成ファイルをそのまま使うと `command is required` で失敗していた (#138 のフォローアップ)
- スケルトンを `input.ExecInput{Cmd: "sh"}` から生成するよう修正

## Test plan
- [x] `go test ./cmd/... ./internal/input/...`
- [x] 生成した skeleton をそのまま確認 → `"command": "sh"` が出力される